### PR TITLE
[WIP] 2.5 アクセス制御とセキュリティ機能

### DIFF
--- a/pkgs/contract/contracts/mocks/ReentrantToken.sol
+++ b/pkgs/contract/contracts/mocks/ReentrantToken.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IDonationPool } from "../interfaces/IDonationPool.sol";
+
+/// @notice Malicious ERC20 that attempts to reenter DonationPool.donate during transferFrom
+contract ReentrantToken is ERC20 {
+  address public pool;
+  bool public reenter;
+
+  constructor() ERC20("ReentrantToken", "RNT") {
+    _mint(msg.sender, 1_000_000 ether);
+  }
+
+  function setPool(address _pool) external {
+    pool = _pool;
+  }
+
+  function setReenter(bool _flag) external {
+    reenter = _flag;
+  }
+
+  // allow receiving ETH for potential donateETH reentry attempts
+  receive() external payable {}
+
+  function transferFrom(address from, address to, uint256 value) public override returns (bool) {
+    if (reenter && pool != address(0)) {
+      // Attempt to reenter DonationPool.donate; should revert with ReentrancyGuard
+      IDonationPool(pool).donate(address(this), 1);
+    }
+    return super.transferFrom(from, to, value);
+  }
+}
+


### PR DESCRIPTION
PR概要

- タイトル: test(donationpool): ACL/リエントランシー/カスタムエラーを網羅
- ブランチ: feature/17
- スコープ: テスト追加＋モック1件（Solidity本体変更なし）
- 目的: 2.5要件（onlyOwner, ReentrancyGuard, カスタムエラー）をテストで担保
- 主要確認: onlyOwner制御/ETH許可判定/カスタムエラー/リエントランシー防止/イベン
トと残高整合

サブタスク

- モック: contracts/mocks/ReentrantToken.sol（transferFrom中にreenter試行）
- テスト: 管理者機能はownerのみ（非ownerはOwnableUnauthorizedAccount）
- テスト: ETH未許可でdonateETH/直送はUnsupportedToken
- テスト: カスタムエラー（ZeroAddress/ZeroAmount/UnsupportedToken）網羅
- テスト: リエントランシーでReentrancyGuardReentrantCall発生を確認
- テスト: Donated/DonatedETHの引数と回数、balanceOfの加算を検証（アドレスは小文
字比較）

closed #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test utility contract for simulating reentrancy attack scenarios in security testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->