### PR TITLE
[WIP] 2.3 残高管理機能の実装

### DIFF
--- a/pkgs/contract/contracts/DonationPool.sol
+++ b/pkgs/contract/contracts/DonationPool.sol
@@ -22,6 +22,10 @@ contract DonationPool is IDonationPool, Ownable, ReentrancyGuard {
   /// @dev token => total balance in pool
   mapping(address => uint256) private _balances;
 
+  /// @dev 追跡中のトークン一覧（getAllBalances 用）
+  address[] private _trackedTokens;
+  mapping(address => bool) private _isTracked;
+
   /// @dev errors
   error ZeroAddress();
   error ZeroAmount();
@@ -34,13 +38,18 @@ contract DonationPool is IDonationPool, Ownable, ReentrancyGuard {
     targetToken = targetToken_;
     // 初期サポートトークン設定
     for (uint256 i = 0; i < initialSupported.length; i++) {
-      supportedTokens[initialSupported[i]] = true;
+      address token = initialSupported[i];
+      supportedTokens[token] = true;
+      _trackToken(token);
     }
   }
 
   /// @notice サポートトークンの設定
   function setSupportedToken(address token, bool supported) external onlyOwner {
     supportedTokens[token] = supported;
+    if (supported) {
+      _trackToken(token);
+    }
   }
 
   /// @notice targetToken の更新
@@ -56,6 +65,7 @@ contract DonationPool is IDonationPool, Ownable, ReentrancyGuard {
 
     IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
     _balances[token] += amount;
+    _trackToken(token);
     emit Donated(msg.sender, token, amount);
   }
 
@@ -65,6 +75,7 @@ contract DonationPool is IDonationPool, Ownable, ReentrancyGuard {
     if (!supportedTokens[address(0)]) revert UnsupportedToken();
 
     _balances[address(0)] += msg.value;
+    _trackToken(address(0));
     emit DonatedETH(msg.sender, msg.value);
   }
 
@@ -73,11 +84,41 @@ contract DonationPool is IDonationPool, Ownable, ReentrancyGuard {
     return _balances[token];
   }
 
+  /// @notice 指定トークンの残高取得（エイリアス）
+  function getBalance(address token) external view returns (uint256) {
+    return _balances[token];
+  }
+
+  /// @notice 追跡中トークンの全残高取得
+  function getAllBalances()
+    external
+    view
+    returns (address[] memory tokens, uint256[] memory balances)
+  {
+    uint256 len = _trackedTokens.length;
+    tokens = new address[](len);
+    balances = new uint256[](len);
+    for (uint256 i = 0; i < len; i++) {
+      address t = _trackedTokens[i];
+      tokens[i] = t;
+      balances[i] = _balances[t];
+    }
+  }
+
   /// @dev 受動的に ETH を受領した場合も寄付扱いにする
   receive() external payable {
     if (msg.value > 0 && supportedTokens[address(0)]) {
       _balances[address(0)] += msg.value;
+      _trackToken(address(0));
       emit DonatedETH(msg.sender, msg.value);
+    }
+  }
+
+  /// @dev トークンを追跡対象に追加（重複排除）
+  function _trackToken(address token) internal {
+    if (!_isTracked[token]) {
+      _isTracked[token] = true;
+      _trackedTokens.push(token);
     }
   }
 }

--- a/pkgs/contract/contracts/interfaces/IDonationPool.sol
+++ b/pkgs/contract/contracts/interfaces/IDonationPool.sol
@@ -24,4 +24,15 @@ interface IDonationPool {
   /// @notice プール内残高の参照
   /// @param token トークンアドレス（ETH の場合は address(0)）
   function balanceOf(address token) external view returns (uint256);
+
+  /// @notice 指定トークンの残高を取得（エイリアス）
+  /// @dev view 関数でガス消費なし
+  function getBalance(address token) external view returns (uint256);
+
+  /// @notice 追跡中の全トークン残高を一括取得
+  /// @dev view 関数でガス消費なし。返却配列は同一インデックスが対応（tokens[i] -> balances[i]）
+  function getAllBalances()
+    external
+    view
+    returns (address[] memory tokens, uint256[] memory balances);
 }


### PR DESCRIPTION
実装内容

- 内部状態
    - mapping(address => uint256) _balances: トークン別残高
    - address[] _trackedTokens + _isTracked: 一括取得用に追跡トークンを保持
- 追跡ロジック
    - constructor で initialSupported を追跡対象に追加
    - setSupportedToken(token, true) で追跡対象に追加
    - donate / donateETH / receive で受領時に追跡対象へ追加
- view 関数
    - getBalance(address token) external view returns (uint256): 残高取得
（balanceOfのエイリアス）
    - getAllBalances() external view returns (address[] tokens, uint256[]
balances): 追跡中トークンの全残高を一括返却（同インデックス対応）
- 既存仕様との整合
    - 既存の balanceOf は維持（後方互換）
    - 既存の onlyOwner / ReentrancyGuard / カスタムエラーは変更なし

変更ファイル

- contracts/DonationPool.sol
    - 追跡配列と追加ロジック、getBalance / getAllBalances 実装
- contracts/interfaces/IDonationPool.sol
    - getBalance / getAllBalances を追加定義

使い方の例

- 単一トークン残高: getBalance(token) または balanceOf(token)
- 一括取得: getAllBalances() → [tokens[], balances[]]

注意点

- getAllBalances は「追跡中トークン」を返します（サポート設定済み、または残高が
発生したトークン）。
- view 関数は revert せず、存在しない/未サポートトークンでも 0 を返します（ETH
は address(0)）。

closed #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `getBalance()` function to query individual token balances
  * Added `getAllBalances()` function to retrieve all tracked token balances in a single call

<!-- end of auto-generated comment: release notes by coderabbit.ai -->