### PR TITLE
swapの時のロジックを若干修正しました！

### DIFF
--- a/pkgs/contract/contracts/DonationPool.sol
+++ b/pkgs/contract/contracts/DonationPool.sol
@@ -166,11 +166,11 @@ contract DonationPool is IDonationPool, Ownable, ReentrancyGuard {
 
     // プール内の内部残高を確認（1:1スワップ）
     if (_balances[usdc] < amount) revert InsufficientBalance();
-    if (_balances[pyusd] < amount) revert InsufficientBalance();
+    // if (_balances[pyusd] < amount) revert InsufficientBalance();
 
     // CEI: 内部残高を先に更新し、その後送金
     _balances[usdc] -= amount; // 受領USDCを消費
-    _balances[pyusd] -= amount; // プールのPYUSD流動性を消費
+    // _balances[pyusd] -= amount; // プールのPYUSD流動性を消費
 
     IERC20(pyusd).safeTransfer(to, amount);
 

--- a/pkgs/contract/scripts/donate.ts
+++ b/pkgs/contract/scripts/donate.ts
@@ -28,8 +28,8 @@ const contract = await viem.getContractAt("DonationPool", contractAddress as `0x
 // token address from comand line args or default to USDC on Arbitrum Sepolia
 const tokenAddress =
   process.argv[6] ||
-  // "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"; // USDC on Arbitrum Sepolia
-  "0x637A1259C6afd7E3AdF63993cA7E58BB438aB1B1"; // PYUSD on Arbitrum Sepolia
+  "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"; // USDC on Arbitrum Sepolia
+  // "0x637A1259C6afd7E3AdF63993cA7E58BB438aB1B1"; // PYUSD on Arbitrum Sepolia
 const amount = BigInt(1e6); // 1 USDC = 1e6
 
 // create ERC20 contract instance using direct viem approach


### PR DESCRIPTION
@tanapl 
swapの際、あらかじめ PYUSDがdonateされていないとswapできないようになっていたので PYUSD側だけ確認のロジックをコメントアウトさせてもらいました(ハッカソン用の一時的に変えました)！

セキュリティ的に課題は残りますが、ハッカソン後に改善しましょう！！
実装ありがとうございました！！

以下、改修後のロジックで実際に動かした時の記録です！！

```bash
========================= [START] =========================
Sender address: 0x51908f598a5e0d8f1a3babfa6df76f9704dad072
ChainID: 421614
Donating to contract DonationPoolModule#DonationPool at address: 0x025755dfebe6eEF0a58cEa71ba3A417f4175CAa3
Swap tx receipt: 0xb24aa4a8226d31dae254c3c2baf55f4f97995d108c39b89ca2de829e6c8bb2b1
========================= [END] =========================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token swap transaction handling to modify PYUSD balance accounting in the donation pool.

* **Chores**
  * Changed default token from PYUSD to USDC on Arbitrum Sepolia network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->